### PR TITLE
Fix regex to handle chromosome names with periods.

### DIFF
--- a/src/cineca/parallel_reditools.py
+++ b/src/cineca/parallel_reditools.py
@@ -165,7 +165,7 @@ if __name__ == '__main__':
     size = comm.Get_size()
 
     options = reditools.parse_options()
-    options["remove_header"] = True
+    #options["remove_header"] = True
     
     parser = argparse.ArgumentParser(description='REDItools 2.0')
     parser.add_argument('-G', '--coverage-file', help='The coverage file of the sample to analyze')

--- a/src/cineca/parallel_reditools.py
+++ b/src/cineca/parallel_reditools.py
@@ -567,7 +567,7 @@ if __name__ == '__main__':
             
             print(little_file)
             # Strip the file ending and split by '#'
-            pieces = re.sub(r"\.[^\.#]*", "", os.path.basename(little_file)).split("#")
+            pieces = re.sub(r"\.[^\.]*$", "", os.path.basename(little_file)).split("#")
             pieces.insert(0, little_file)
             little_files.append(pieces)
 

--- a/src/cineca/parallel_reditools.py
+++ b/src/cineca/parallel_reditools.py
@@ -165,7 +165,8 @@ if __name__ == '__main__':
     size = comm.Get_size()
 
     options = reditools.parse_options()
-    #options["remove_header"] = True
+    # Until tabix can properly index the output, the header is disruptive.
+    options["remove_header"] = True
     
     parser = argparse.ArgumentParser(description='REDItools 2.0')
     parser.add_argument('-G', '--coverage-file', help='The coverage file of the sample to analyze')

--- a/src/cineca/parallel_reditools.py
+++ b/src/cineca/parallel_reditools.py
@@ -566,7 +566,8 @@ if __name__ == '__main__':
             if little_file.endswith("groups.txt"): continue
             
             print(little_file)
-            pieces = re.sub("\..*", "", os.path.basename(little_file)).split("#")
+            # Strip the file ending and split by '#'
+            pieces = re.sub(r"\.[^\.#]*", "", os.path.basename(little_file)).split("#")
             pieces.insert(0, little_file)
             little_files.append(pieces)
 

--- a/src/cineca/reditools2_multisample.py
+++ b/src/cineca/reditools2_multisample.py
@@ -515,7 +515,7 @@ if __name__ == '__main__':
                 if little_file.endswith("groups.txt"): continue
                 
                 print(little_file)
-                pieces = re.sub(r"\.[^\.#]*", "", os.path.basename(little_file)).split("#")
+                pieces = re.sub(r"\.[^\.]*$", "", os.path.basename(little_file)).split("#")
                 pieces.insert(0, little_file)
                 little_files.append(pieces)
     

--- a/src/cineca/reditools2_multisample.py
+++ b/src/cineca/reditools2_multisample.py
@@ -144,7 +144,8 @@ if __name__ == '__main__':
     size = comm.Get_size()
 
     options = reditools.parse_options()
-    #options["remove_header"] = True
+    # Until tabix can properly index the output, the header is disruptive.
+    options["remove_header"] = True
     
     parser = argparse.ArgumentParser(description='REDItools 2.0')
     parser.add_argument('-D', '--coverage-dir', help='The coverage directory containing the coverage file of the sample to analyze divided by chromosome')

--- a/src/cineca/reditools2_multisample.py
+++ b/src/cineca/reditools2_multisample.py
@@ -144,7 +144,7 @@ if __name__ == '__main__':
     size = comm.Get_size()
 
     options = reditools.parse_options()
-    options["remove_header"] = True
+    #options["remove_header"] = True
     
     parser = argparse.ArgumentParser(description='REDItools 2.0')
     parser.add_argument('-D', '--coverage-dir', help='The coverage directory containing the coverage file of the sample to analyze divided by chromosome')

--- a/src/cineca/reditools2_multisample.py
+++ b/src/cineca/reditools2_multisample.py
@@ -515,7 +515,7 @@ if __name__ == '__main__':
                 if little_file.endswith("groups.txt"): continue
                 
                 print(little_file)
-                pieces = re.sub("\..*", "", os.path.basename(little_file)).split("#")
+                pieces = re.sub(r"\.[^\.#]*", "", os.path.basename(little_file)).split("#")
                 pieces.insert(0, little_file)
                 little_files.append(pieces)
     


### PR DESCRIPTION
Chromosome names with periods in them, such as are assigned to scaffolds in many assemblies, were not handled properly by reditools2. The new regex will only remove the final file prefix (a period followed by zero or more non-periods) from the intermediate file chunks.